### PR TITLE
Fix proration mode always set to deferred

### DIFF
--- a/src/js/lib/play-billing.js
+++ b/src/js/lib/play-billing.js
@@ -195,10 +195,16 @@ export class PlayBillingService {
     See https://developer.android.com/google/play/billing/subscriptions#proration-recommendations
     for more information about the different proration modes and recommendations.
     */
-    let prorationMode = 'deferred';
-    if (subType === 'upgrade') {
-      prorationMode = 'immediateAndChargeProratedPrice';
+    let prorationMode = null;
+    switch (subType) {
+      case 'upgrade':
+        prorationMode = 'immediateAndChargeProratedPrice';
+        break;
+      case 'downgrade':
+        prorationMode = 'deferred';
+        break;
     }
+
     // Build payment request
     const paymentMethod = [
       {

--- a/src/js/lib/play-billing.js
+++ b/src/js/lib/play-billing.js
@@ -195,7 +195,7 @@ export class PlayBillingService {
     See https://developer.android.com/google/play/billing/subscriptions#proration-recommendations
     for more information about the different proration modes and recommendations.
     */
-    let prorationMode = null;
+    let prorationMode;
     switch (subType) {
       case 'upgrade':
         prorationMode = 'immediateAndChargeProratedPrice';


### PR DESCRIPTION
There was a bug where the proration mode was being set to deferred by default, even for regular (non up/downgrade) purchases. This was causing the Play Billing purchase UI not to show up because a proration mode was set but no purchase token for the old SKU was set.